### PR TITLE
handle DI_BUFFEROVERFLOW result correctly

### DIFF
--- a/source/gamepad/Gamepad_windows_dinput.c
+++ b/source/gamepad/Gamepad_windows_dinput.c
@@ -964,7 +964,7 @@ void Gamepad_processEvents() {
 					IDirectInputDevice8_Acquire(devicePrivate->deviceInterface);
 					result = IDirectInputDevice8_GetDeviceData(devicePrivate->deviceInterface, sizeof(DIDEVICEOBJECTDATA), events, &eventCount, 0);
 				}
-				if (result != DI_OK) {
+				if (SUCCEEDED(result)) {
 					removeDevice(deviceIndex);
 					deviceIndex--;
 					continue;


### PR DESCRIPTION
IDirectInputDevice8_GetDeviceData will return DI_BUFFEROVERFLOW sometimes, this happened during testing with a Sony DS4 controller.
This result should not lead to a device disconnect.