### PR TITLE
stdbool.h replacement for VS2010

### DIFF
--- a/source/gamepad/Gamepad.h
+++ b/source/gamepad/Gamepad.h
@@ -26,7 +26,13 @@
 extern "C" {
 #endif
 
+#if _MSC_VER <= 1600
+#define bool int
+#define true 1
+#define false 0
+#else
 #include <stdbool.h>
+#endif
 
 struct Gamepad_device {
 	// Unique device identifier for application session, starting at 0 for the first device attached and


### PR DESCRIPTION
To fix compilation errors in Visual Studio 2010, I'm adding some definitions that will replicate the functionality needed from `stdbool.h`, which is not available in VS2010.