### PR TITLE
Memory leak fixes

### DIFF
--- a/source/gamepad/Gamepad_linux.c
+++ b/source/gamepad/Gamepad_linux.c
@@ -125,6 +125,10 @@ void Gamepad_shutdown() {
 		for (eventIndex = 0; eventIndex < eventCount; eventIndex++) {
 			if (eventQueue[eventIndex].eventType == GAMEPAD_EVENT_DEVICE_REMOVED) {
 				disposeDevice(eventQueue[eventIndex].eventData);
+			} else if (eventQueue[eventIndex].eventType == GAMEPAD_EVENT_BUTTON_DOWN ||
+				   eventQueue[eventIndex].eventType == GAMEPAD_EVENT_BUTTON_UP ||
+				   eventQueue[eventIndex].eventType == GAMEPAD_EVENT_AXIS_MOVED) {
+				free(eventQueue[eventIndex].eventData);
 			}
 		}
 		

--- a/source/gamepad/Gamepad_linux.c
+++ b/source/gamepad/Gamepad_linux.c
@@ -25,7 +25,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <limits.h>
+#include <linux/limits.h>
 #include <linux/input.h>
 #define __USE_UNIX98
 #include <pthread.h>

--- a/source/gamepad/Gamepad_macosx.c
+++ b/source/gamepad/Gamepad_macosx.c
@@ -285,7 +285,7 @@ static void onDeviceMatched(void * context, IOReturn result, void * sender, IOHI
 	
 	cfProductName = IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductKey));
 	if (cfProductName == NULL || CFGetTypeID(cfProductName) != CFStringGetTypeID()) {
-		description = malloc(strlen("[Unknown]" + 1));
+		description = malloc(strlen("[Unknown]") + 1);
 		strcpy(description, "[Unknown]");
 		
 	} else {


### PR DESCRIPTION
These changes allow Gamepad_init() and Gamepad_shutdown() to be called repeatedly without memory leaks.